### PR TITLE
Cleanup CI output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ if [ -e yarn.lock ]; then
 
   if [ "$CRA_VERSION" != "null" ]; then
     echo "Detected Create React App ($CRA_VERSION)"
-    yes | yarn eject
+    echo yes | yarn eject
     export WEBPACK_CONFIG_PATH='./config/webpack.config.js'
   fi
 
@@ -34,7 +34,7 @@ elif [ -e package.json ]; then
 
   if [ "$CRA_VERSION" != "null" ]; then
     echo "Detected Create React App ($CRA_VERSION)"
-    yes | npm run eject
+    echo yes | npm run eject
     export WEBPACK_CONFIG_PATH='./config/webpack.config.js'
   fi
 


### PR DESCRIPTION
During CI run `yes` will continually print `y` while the `eject`-script is running, this clutters up the console horribly.

Only one `"yes"` is needed to pass the "are you sure" check